### PR TITLE
feat: 체험 상세 페이지 갤러리 추가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["swiper"]
+}

--- a/app/activities/_components/ActivityImageGallery.tsx
+++ b/app/activities/_components/ActivityImageGallery.tsx
@@ -1,0 +1,43 @@
+/*
+    체험상세(activities) 페이지의 갤러리(ActivityImageGallery) 컴포넌트
+    체험상세 page에서 받아온 정보 중 bannerImage와 subImages의 url을 전달받아 display
+    Todo: API 연결 - 현재 mock data와 연동되어있음
+*/
+
+"use client";
+
+import dynamic from "next/dynamic";
+import React from "react";
+
+// SwiperContainer를 동적으로 가져옵니다.
+const DynamicSwiperContainer = dynamic(() => import("./SwiperContainer"), { ssr: false });
+
+interface ImageGalleryProps {
+  images: string[];
+  bannerImage: string;
+}
+
+const ActivityImageGallery: React.FC<ImageGalleryProps> = ({ images, bannerImage }) => {
+  return (
+    <>
+      {/* 모바일 Swiper */}
+      <div className="block md:hidden xl:hidden">
+        <DynamicSwiperContainer images={[bannerImage, ...images]} />
+      </div>
+
+      {/* 태블릿과 데스크탑 그리드 */}
+      <div className="hidden h-[600px] grid-cols-4 grid-rows-2 gap-4 md:grid xl:grid">
+        <div className="col-span-2 row-span-2">
+          <img src={bannerImage} alt="Banner" className="h-full w-full object-cover" />
+        </div>
+        {images.slice(0, 4).map((image, index) => (
+          <div key={index} className="relative h-full">
+            <img src={image} alt={`Image ${index + 1}`} className="h-full w-full object-cover" />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default ActivityImageGallery;

--- a/app/activities/_components/ActivityTitle.tsx
+++ b/app/activities/_components/ActivityTitle.tsx
@@ -4,42 +4,37 @@
     Todo: API 연결
 */
 
-import React from 'react';
-import Image from 'next/image';
-import star from '@/app/assets/icon/ic_star_on.svg';
-import locationIcon from '@/app/assets/icon/ic_location.svg';
+import locationIcon from "@/app/assets/icon/ic_location.svg";
+import star from "@/app/assets/icon/ic_star_on.svg";
+import Image from "next/image";
+import React from "react";
 
 interface ActivityTitleProps {
-    category: string;
-    title: string;
-    rating: number;
-    reviewCount: number;
-    location: string;
-  }
+  category: string;
+  title: string;
+  rating: number;
+  reviewCount: number;
+  location: string;
+}
 
-  const ActivityTitle: React.FC<ActivityTitleProps> = ({ category, title, rating, reviewCount, location }) => {
-    return (
+const ActivityTitle: React.FC<ActivityTitleProps> = ({ category, title, rating, reviewCount, location }) => {
+  return (
     <>
-       <div className="md-regular pb-[10px]">
-            {category}
-        </div>
-        <div className="text-2xl-bold md:text-3xl-bold xl:text-3xl-bold pb-[16px]">
-            {title}
-        </div> 
-        <div className="md-regular flex items-center space-x-3">
-            <span className="flex items-center space-x-[4px] md:space-x-[6px] xl:space-x-[6px]">
-                <Image src={star} alt="rating" width={16} height={16} />
-                <span>{rating}</span>
-                <span>({reviewCount})</span>
-            </span>
+      <div className="md-regular pb-[10px]">{category}</div>
+      <div className="pb-[16px] text-2xl-bold md:text-3xl-bold xl:text-3xl-bold">{title}</div>
+      <div className="md-regular flex items-center space-x-3">
+        <span className="flex items-center space-x-[4px] md:space-x-[6px] xl:space-x-[6px]">
+          <Image src={star} alt="rating" width={16} height={16} />
+          <span>{rating}</span>
+          <span>({reviewCount})</span>
+        </span>
         <span className="flex items-center space-x-[2px]">
-            <Image src={locationIcon} alt="location" width={18} height={18} />
-            <span>{location}</span>
+          <Image src={locationIcon} alt="location" width={18} height={18} />
+          <span>{location}</span>
         </span>
       </div>
     </>
-    );
-  }
-  
-  export default ActivityTitle;
-  
+  );
+};
+
+export default ActivityTitle;

--- a/app/activities/_components/SwiperContainer.tsx
+++ b/app/activities/_components/SwiperContainer.tsx
@@ -42,7 +42,7 @@ const SwiperContainer: React.FC<SwiperContainerProps> = ({ images }) => {
       onSwiper={swiper => setSwiperInstance(swiper)}
       modules={[Navigation, Pagination, Scrollbar]}
       spaceBetween={50}
-      slidesPerView={1} // 모바일에서는 한 번에 하나씩 보이게
+      slidesPerView={1}
       pagination={{ clickable: true }}
       navigation
       scrollbar={{ draggable: true }}

--- a/app/activities/_components/SwiperContainer.tsx
+++ b/app/activities/_components/SwiperContainer.tsx
@@ -1,0 +1,61 @@
+/*
+    체험 상세 페이지의 mobile 버전 이미지 갤러리
+*/
+
+import React, { useEffect, useState } from "react";
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+import "swiper/css/scrollbar";
+import { Navigation, Pagination, Scrollbar } from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/react";
+
+interface SwiperContainerProps {
+  images: string[];
+}
+
+const SwiperContainer: React.FC<SwiperContainerProps> = ({ images }) => {
+  const [swiperInstance, setSwiperInstance] = useState<any>(null);
+
+  useEffect(() => {
+    if (swiperInstance) {
+      const handleProgress = (e: CustomEvent) => {
+        console.log(e.detail);
+      };
+
+      const handleSlideChange = () => {
+        console.log("slide changed");
+      };
+
+      swiperInstance.on("progress", handleProgress);
+      swiperInstance.on("slideChange", handleSlideChange);
+
+      return () => {
+        swiperInstance.off("progress", handleProgress);
+        swiperInstance.off("slideChange", handleSlideChange);
+      };
+    }
+  }, [swiperInstance]);
+
+  return (
+    <Swiper
+      onSwiper={swiper => setSwiperInstance(swiper)}
+      modules={[Navigation, Pagination, Scrollbar]}
+      spaceBetween={50}
+      slidesPerView={1} // 모바일에서는 한 번에 하나씩 보이게
+      pagination={{ clickable: true }}
+      navigation
+      scrollbar={{ draggable: true }}
+      loop
+      style={{ width: "100%", height: "310px" }}
+    >
+      {images.map((image, index) => (
+        <SwiperSlide key={index}>
+          <img src={image} alt={`Slide ${index + 1}`} className="h-full w-full object-cover" />
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
+};
+
+export default SwiperContainer;

--- a/app/activities/_components/SwiperContainer.tsx
+++ b/app/activities/_components/SwiperContainer.tsx
@@ -2,7 +2,7 @@
     체험 상세 페이지의 mobile 버전 이미지 갤러리
 */
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
@@ -15,31 +15,8 @@ interface SwiperContainerProps {
 }
 
 const SwiperContainer: React.FC<SwiperContainerProps> = ({ images }) => {
-  const [swiperInstance, setSwiperInstance] = useState<any>(null);
-
-  useEffect(() => {
-    if (swiperInstance) {
-      const handleProgress = (e: CustomEvent) => {
-        console.log(e.detail);
-      };
-
-      const handleSlideChange = () => {
-        console.log("slide changed");
-      };
-
-      swiperInstance.on("progress", handleProgress);
-      swiperInstance.on("slideChange", handleSlideChange);
-
-      return () => {
-        swiperInstance.off("progress", handleProgress);
-        swiperInstance.off("slideChange", handleSlideChange);
-      };
-    }
-  }, [swiperInstance]);
-
   return (
     <Swiper
-      onSwiper={swiper => setSwiperInstance(swiper)}
       modules={[Navigation, Pagination, Scrollbar]}
       spaceBetween={50}
       slidesPerView={1}

--- a/app/activities/_components/swiper.d.ts
+++ b/app/activities/_components/swiper.d.ts
@@ -1,0 +1,6 @@
+declare namespace JSX {
+  interface IntrinsicElements {
+    "swiper-container": any;
+    "swiper-slide": any;
+  }
+}

--- a/app/activities/_components/swiper.d.ts
+++ b/app/activities/_components/swiper.d.ts
@@ -1,3 +1,7 @@
+/*
+    Swiper 라이브러리의 swiper-container와 swiper-slide에 대한 타입 정의 파일
+*/
+
 declare namespace JSX {
   interface IntrinsicElements {
     "swiper-container": any;

--- a/app/activities/page.tsx
+++ b/app/activities/page.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import ActivityImageGallery from "./_components/ActivityImageGallery";
 import ActivityTitle from "./_components/ActivityTitle";
 
 const mockData = {
@@ -10,7 +12,7 @@ const mockData = {
   price: 1000000,
   address: "서울특별시 강남구 테헤란로 427",
   bannerImageUrl:
-    "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/6-11_694_1721969204805.png",
+    "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/6-11_694_1721994832772.jpeg",
   rating: 4.8,
   reviewCount: 589,
   createdAt: "2024-07-26T13:49:15.140Z",
@@ -20,6 +22,21 @@ const mockData = {
       id: 2627,
       imageUrl:
         "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/6-11_694_1721969278121.png",
+    },
+    {
+      id: 2628,
+      imageUrl:
+        "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/6-11_694_1721994813442.png",
+    },
+    {
+      id: 2629,
+      imageUrl:
+        "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/6-11_694_1721969204805.png",
+    },
+    {
+      id: 2630,
+      imageUrl:
+        "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/6-11_694_1721994869821.jpeg",
     },
   ],
   schedules: [
@@ -50,7 +67,9 @@ const mockData = {
   ],
 };
 
-function Activities() {
+const images = mockData.subImages.map(image => image.imageUrl);
+
+const Activities: React.FC = () => {
   return (
     <div>
       Activities
@@ -61,8 +80,9 @@ function Activities() {
         reviewCount={mockData.reviewCount}
         location={mockData.address}
       />
+      <ActivityImageGallery bannerImage={mockData.bannerImageUrl} images={images} />
     </div>
   );
-}
+};
 
 export default Activities;

--- a/app/activities/page.tsx
+++ b/app/activities/page.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
-import ActivityTitle from './_components/ActivityTitle';
+import ActivityTitle from "./_components/ActivityTitle";
 
 const mockData = {
   id: 1932,
   userId: 694,
   title: "함께 하면 즐거운 곽철이와 함께 춤을",
-  description: "둠칫 둠칫 두둠칫 날이면 날마다 오는 체험이 아니다! 곽철이와 함께 댄스를 출 수 있는 특별한 기회! 특별한 가격에 모십니다! 곽철이와 함께 춤을!! 💃🕺",
+  description:
+    "둠칫 둠칫 두둠칫 날이면 날마다 오는 체험이 아니다! 곽철이와 함께 댄스를 출 수 있는 특별한 기회! 특별한 가격에 모십니다! 곽철이와 함께 춤을!! 💃🕺",
   category: "투어",
   price: 1000000,
   address: "서울특별시 강남구 테헤란로 427",
-  bannerImageUrl: "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/6-11_694_1721969204805.png",
+  bannerImageUrl:
+    "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/6-11_694_1721969204805.png",
   rating: 4.8,
   reviewCount: 589,
   createdAt: "2024-07-26T13:49:15.140Z",
@@ -17,47 +18,49 @@ const mockData = {
   subImages: [
     {
       id: 2627,
-      imageUrl: "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/6-11_694_1721969278121.png"
-    }
+      imageUrl:
+        "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/6-11_694_1721969278121.png",
+    },
   ],
   schedules: [
     {
       id: 7349,
       date: "2024-12-01",
       startTime: "12:00",
-      endTime: "13:00"
+      endTime: "13:00",
     },
     {
       id: 7350,
       date: "2024-12-05",
       startTime: "12:00",
-      endTime: "13:00"
+      endTime: "13:00",
     },
     {
       id: 7351,
       date: "2024-12-05",
       startTime: "13:00",
-      endTime: "14:00"
+      endTime: "14:00",
     },
     {
       id: 7352,
       date: "2024-12-05",
       startTime: "14:00",
-      endTime: "15:00"
-    }
-  ]
+      endTime: "15:00",
+    },
+  ],
 };
-
 
 function Activities() {
   return (
-    <div>Activities
+    <div>
+      Activities
       <ActivityTitle
         category={mockData.category}
         title={mockData.title}
         rating={mockData.rating}
         reviewCount={mockData.reviewCount}
-        location={mockData.address}/>
+        location={mockData.address}
+      />
     </div>
   );
 }

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -3,6 +3,9 @@
 @tailwind utilities;
 @import "./reset.css";
 
+/* Swiper styles - 이미지 갤러리 라이브러리 */
+@import "swiper/swiper-bundle.css";
+
 body {
-  background-color: #FAFAFA;
+  background-color: #fafafa;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@tanstack/react-query": "^5.51.11",
         "next": "14.2.5",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "swiper": "^11.1.7"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4501,6 +4502,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.7.tgz",
+      "integrity": "sha512-2EpQvhgKb+DNbi8/i9uRXhddivcMZQxca341t2NZYV1xroCR2p4YtYd3azuqRQ4OEBGcG4nv3aN24O80bMipow==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@tanstack/react-query": "^5.51.11",
     "next": "14.2.5",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "swiper": "^11.1.7"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## 🔎 작업 내용
- 체험 상세 페이지의 사진을 display하는 갤러리를 추가했습니다.

## 📜 간단한 코드 설명 및 사용설명서
- Swiper라는 라이브러리를 추가했습니다.
- `swiper.d.ts` 파일에는 swiper를 사용하기 위해 swiper-container와 swiper-slide을 타입 정의했습니다.
- `SwiperContainer.tsx`는 모바일 버전의 갤러리를 만들었고
- `ActivityImageGallery`에는 모바일 버전의 갤러리와, tabelt&desktop 버전의 갤러리 코드를 넣었습니다.


## 📷 결과물 (image , gif ..)
- mobile
![2024-07-26-22-29-16](https://github.com/user-attachments/assets/fb8d7624-debd-4e9d-9c27-ec3d04020eb3)
![2024-07-26-22-29-21](https://github.com/user-attachments/assets/14bd8eca-c066-4e94-ae60-8a7300b0ed91)

- tablet&desktop
![image](https://github.com/user-attachments/assets/4be92575-838d-4427-ac28-63a2f75ba1ee)


### 👀 공유포인트 및 이슈
- Swiper 라이브러리 설치했기 때문에, 이 branch가 merge된 후 pull 받아오시면 잊지 말고 npm install 해주세요~
- 현재는 /activities 페이지의 mockdata를 이용해서 props로 데이터를 받아오고 있으며, 추후 API를 연결해야 합니다.