### PR TITLE
feat: 드롭다운 컴포넌트 & 체험상세 페이지 드롭다운 메뉴(케밥버튼) 생성

### DIFF
--- a/app/activities/_components/DropDownMenu.tsx
+++ b/app/activities/_components/DropDownMenu.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import KebabBtn from "@/app/assets/icon/ic_meatball.svg";
+import Dropdown from "@/app/components/DropDown/DropDown";
+import Image from "next/image";
+import { FC } from "react";
+
+const DropDownMenu: FC = () => {
+  const handleEdit = () => {
+    console.log("Edit action triggered");
+  };
+
+  const handleDelete = () => {
+    console.log("Delete action triggered");
+  };
+
+  const dropdownItems = [
+    { label: "수정하기", action: handleEdit },
+    { label: "삭제하기", action: handleDelete },
+  ];
+
+  return (
+    <Dropdown
+      items={dropdownItems}
+      trigger={<Image src={KebabBtn} alt="menu" width={32} height={32} />}
+      dropdownClassName="xl:text-lg md:text-lg text-sm"
+      itemClassName="text-gray-600 font-medium w-[140px] xl:h-[58px] md:w-[160px] md:h-[58px] xl:w-[160px] xl:h-[58px]"
+    />
+  );
+};
+
+export default DropDownMenu;

--- a/app/activities/_components/DropDownMenu.tsx
+++ b/app/activities/_components/DropDownMenu.tsx
@@ -1,3 +1,8 @@
+/*
+  체험 상세 페이지 DropDown 메뉴 + 케밥 버튼
+  Todo: 수정하기, 삭제하기 기능 및 페이지 연결하기
+*/
+
 "use client";
 
 import KebabBtn from "@/app/assets/icon/ic_meatball.svg";
@@ -23,8 +28,7 @@ const DropDownMenu: FC = () => {
     <Dropdown
       items={dropdownItems}
       trigger={<Image src={KebabBtn} alt="menu" width={32} height={32} />}
-      dropdownClassName="xl:text-lg md:text-lg text-sm"
-      itemClassName="text-gray-600 font-medium w-[140px] xl:h-[58px] md:w-[160px] md:h-[58px] xl:w-[160px] xl:h-[58px]"
+      itemClassName="w-[140px] xl:h-[58px] md:w-[160px] md:h-[58px] xl:w-[160px] xl:h-[58px]"
     />
   );
 };

--- a/app/activities/_components/SwiperContainer.tsx
+++ b/app/activities/_components/SwiperContainer.tsx
@@ -23,7 +23,6 @@ const SwiperContainer: React.FC<SwiperContainerProps> = ({ images }) => {
       pagination={{ clickable: true }}
       navigation
       scrollbar={{ draggable: true }}
-      loop
       style={{ width: "100%", height: "310px" }}
     >
       {images.map((image, index) => (

--- a/app/activities/page.tsx
+++ b/app/activities/page.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ActivityImageGallery from "./_components/ActivityImageGallery";
 import ActivityTitle from "./_components/ActivityTitle";
+import DropDownMenu from "./_components/DropDownMenu";
 
 const mockData = {
   id: 1932,
@@ -73,13 +74,20 @@ const Activities: React.FC = () => {
   return (
     <div>
       Activities
-      <ActivityTitle
-        category={mockData.category}
-        title={mockData.title}
-        rating={mockData.rating}
-        reviewCount={mockData.reviewCount}
-        location={mockData.address}
-      />
+      <div className="flex items-center justify-between">
+        <div className="flex-1">
+          <ActivityTitle
+            category={mockData.category}
+            title={mockData.title}
+            rating={mockData.rating}
+            reviewCount={mockData.reviewCount}
+            location={mockData.address}
+          />
+        </div>
+        <div className="flex-none">
+          <DropDownMenu />
+        </div>
+      </div>
       <ActivityImageGallery bannerImage={mockData.bannerImageUrl} images={images} />
     </div>
   );

--- a/app/activities/page.tsx
+++ b/app/activities/page.tsx
@@ -1,3 +1,14 @@
+/*
+  체험 상세 페이지
+  Todo: 
+    (1)체험 상세, 
+    (2)카카오 지도 연결,
+    (3)후기 연결,
+    (4)예약 관리,
+    (5)동적 라우팅 연결하기, 
+    (6)MockData 없애고 실제 API와 데이터 연결하기
+*/
+
 import React from "react";
 import ActivityImageGallery from "./_components/ActivityImageGallery";
 import ActivityTitle from "./_components/ActivityTitle";

--- a/app/components/DropDown/DropDown.tsx
+++ b/app/components/DropDown/DropDown.tsx
@@ -1,3 +1,7 @@
+/*
+  DropDown 메뉴 만들기 위한 공용 컴포넌트
+*/
+
 import { FC, ReactNode, useEffect, useRef, useState } from "react";
 
 interface DropdownProps {

--- a/app/components/DropDown/DropDown.tsx
+++ b/app/components/DropDown/DropDown.tsx
@@ -1,0 +1,56 @@
+import { FC, ReactNode, useEffect, useRef, useState } from "react";
+
+interface DropdownProps {
+  items: { label: string; action: () => void }[];
+  dropdownClassName?: string;
+  itemClassName?: string;
+  trigger: ReactNode;
+}
+
+const Dropdown: FC<DropdownProps> = ({ items, dropdownClassName, itemClassName, trigger }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const toggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div className="relative inline-block" ref={menuRef}>
+      <button onClick={toggleDropdown} className="flex items-center justify-center">
+        {trigger}
+      </button>
+      {isOpen && (
+        <ul
+          className={`absolute right-0 z-10 mt-2 rounded border border-gray-300 bg-white shadow-lg ${dropdownClassName}`}
+        >
+          {items.map((item, index) => (
+            <li key={index} className={`p-[8px] ${itemClassName}`}>
+              <button
+                onClick={item.action}
+                className="md-medium w-full rounded px-4 py-2 text-left text-center text-gray-600 hover:bg-primary-green-100 hover:text-primary-black-100 focus:outline-none md:text-2lg-medium xl:text-2lg-medium"
+              >
+                {item.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;


### PR DESCRIPTION
## 🔎 작업 내용
- dropdown 공용 컴포넌트 개발
- 체험 상세 페이지에 드롭다운 메뉴(케밥버튼) 생성

## 📜 간단한 코드 설명 및 사용설명서
# DropDown 컴포넌트:
- DropDown 컴포넌트 import한다.
- items 배열을 사용하여 드롭다운 메뉴 항목을 정의한다.
예시:
```
 const dropdownItems = [
    { label: '수정하기', action: handleEdit },
    { label: '삭제하기', action: handleDelete },
  ];
```
- dropdownClassName과 itemClassName을 사용하여 스타일을 커스터마이징 한다.
예시:
```
<Dropdown
      items={dropdownItems}
      trigger={<Image src={KebabBtn} alt="menu" width={32} height={32} />}
      dropdownClassName="xl:text-lg md:text-lg text-sm"
      itemClassName="text-gray-600 font-medium w-[160px] h-[58px]"
    />
```

## 📷 결과물 (image , gif ..)
![2024-07-27-15-37-51](https://github.com/user-attachments/assets/07338412-3e70-433d-887c-65e7700f3c1f)


### 👀 공유포인트 및 이슈
