### PR TITLE
feat: 체험 상세 페이지 체험 설명 완성

### DIFF
--- a/app/activities/_components/ActivityDescription.tsx
+++ b/app/activities/_components/ActivityDescription.tsx
@@ -1,0 +1,16 @@
+import { FC } from "react";
+
+interface ActivityDescriptionProps {
+  description: string;
+}
+
+const ActivityDescription: FC<ActivityDescriptionProps> = ({ description }) => {
+  return (
+    <div className="with-full px-6 py-4 text-primary-black-100">
+      <div className="pb-4 text-[20px] font-bold">체험설명</div>
+      <div className="text-lg-semibold">{description}</div>
+    </div>
+  );
+};
+
+export default ActivityDescription;

--- a/app/activities/_components/ActivityDescription.tsx
+++ b/app/activities/_components/ActivityDescription.tsx
@@ -1,5 +1,6 @@
 /*
     체험 상세 페이지 체험 설명 컴포넌트
+    TODO: API 연결(현재: MockData 연결됨)
 */
 
 import { FC } from "react";
@@ -10,12 +11,15 @@ interface ActivityDescriptionProps {
 
 const ActivityDescription: FC<ActivityDescriptionProps> = ({ description }) => {
   return (
-    <div className="with-full px-6 py-4 text-primary-black-100">
-      <hr className="my-4 border-t border-gray-300" />
-      <div className="pb-4 text-[20px] font-bold">체험설명</div>
-      <div className="text-lg-semibold">{description}</div>
-      <hr className="my-4 border-t border-gray-300" />
-    </div>
+    <>
+      <hr className="my-4 hidden border-t border-gray-300 md:block xl:block" />
+      <div className="with-full px-6 py-4 text-primary-black-100">
+        <div className="pb-4 text-[20px] font-bold">체험설명</div>
+        <div className="text-lg-semibold">{description}</div>
+        <hr className="my-4 border-t border-gray-300 md:hidden xl:hidden" />
+      </div>
+      <hr className="my-4 hidden border-t border-gray-300 md:block xl:block" />
+    </>
   );
 };
 

--- a/app/activities/_components/ActivityDescription.tsx
+++ b/app/activities/_components/ActivityDescription.tsx
@@ -1,3 +1,7 @@
+/*
+    체험 상세 페이지 체험 설명 컴포넌트
+*/
+
 import { FC } from "react";
 
 interface ActivityDescriptionProps {
@@ -7,8 +11,10 @@ interface ActivityDescriptionProps {
 const ActivityDescription: FC<ActivityDescriptionProps> = ({ description }) => {
   return (
     <div className="with-full px-6 py-4 text-primary-black-100">
+      <hr className="my-4 border-t border-gray-300" />
       <div className="pb-4 text-[20px] font-bold">체험설명</div>
       <div className="text-lg-semibold">{description}</div>
+      <hr className="my-4 border-t border-gray-300" />
     </div>
   );
 };

--- a/app/activities/_components/ActivityImageGallery.tsx
+++ b/app/activities/_components/ActivityImageGallery.tsx
@@ -33,6 +33,7 @@ const ActivityImageGallery: React.FC<ImageGalleryProps> = ({ images, bannerImage
             src={bannerImage}
             alt="Banner"
             fill
+            priority
             className="object-cover"
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />

--- a/app/activities/page.tsx
+++ b/app/activities/page.tsx
@@ -10,6 +10,7 @@
 */
 
 import React from "react";
+import ActivityDescription from "./_components/ActivityDescription";
 import ActivityImageGallery from "./_components/ActivityImageGallery";
 import ActivityTitle from "./_components/ActivityTitle";
 import DropDownMenu from "./_components/DropDownMenu";
@@ -100,6 +101,7 @@ const Activities: React.FC = () => {
         </div>
       </div>
       <ActivityImageGallery bannerImage={mockData.bannerImageUrl} images={images} />
+      <ActivityDescription description={mockData.description} />
     </div>
   );
 };


### PR DESCRIPTION
## 🔎 작업 내용
- ActivityDescription: 체험 상세 페이지의 체험 설명 완성했습니다.
- Gallery: Image 컴포넌트 처리 과정 중에 warning사인 떠서 banner이미지에 priority 추가 했습니다.

## 📷 결과물 (image , gif ..)
![image](https://github.com/user-attachments/assets/cbaf159c-3fc9-44cc-9509-a2457b92aa1a)
![image](https://github.com/user-attachments/assets/88f163a8-453b-4dea-90ca-af5ac2e3dbaf)

### 👀 공유포인트 및 이슈

