### PR TITLE
feat: 체험상세 페이지 후기 pagination 적용

### DIFF
--- a/app/(features)/activities/[activityId]/page.tsx
+++ b/app/(features)/activities/[activityId]/page.tsx
@@ -3,9 +3,10 @@
 /*
   체험 상세 페이지
   Todo: 
-    (1)카카오 지도 연결,
-    (2)예약 관리,
-    (3)MockData 없애고 실제 API와 데이터 연결하기
+    (1)MockData 없애고 실제 API와 데이터 연결하기
+    (2)Dropdown menu- '내가만든 체험인 경우에만 나타나도록 적용
+    (3)내가 만든 체험인 경우 예약카드 보이지 않게하기
+    (4)예약완료시 예약완료 모달창 연결
 */
 
 import { useEffect, useState } from "react";

--- a/app/(features)/activities/_components/ActivityReviews.tsx
+++ b/app/(features)/activities/_components/ActivityReviews.tsx
@@ -1,11 +1,12 @@
 /*
     체험 상세 페이지 후기 컴포넌트
-    TODO: API 연결(현재: MockData 연결됨). Pagination구현(TanStack Query 적용하면서 구현 예정)
+    TODO: API 연결(현재: MockData 연결됨).
 */
 
+import Pagination from "@/components/Pagination";
 import star from "@icon/ic_star_on.svg";
 import Image from "next/image";
-import { FC } from "react";
+import { FC, useState } from "react";
 import Review from "./Review";
 
 interface ReviewProps {
@@ -23,6 +24,21 @@ const getSatisfactionLabel = (rating: number): string => {
 
 const ActivityReviews: FC<ReviewProps> = ({ averageRating = 0, totalCount = 0, reviews }) => {
   const satisfactionLabel = getSatisfactionLabel(averageRating);
+
+  // 상태 추가: 현재 페이지와 페이지 당 리뷰 수
+  const [currentPage, setCurrentPage] = useState(1);
+  const reviewsPerPage = 3; // 한 페이지에 표시할 리뷰 수
+
+  // 현재 페이지에 표시할 리뷰 계산
+  const indexOfLastReview = currentPage * reviewsPerPage;
+  const indexOfFirstReview = indexOfLastReview - reviewsPerPage;
+  const currentReviews = reviews.slice(indexOfFirstReview, indexOfLastReview);
+
+  // 페이지 변경 함수 정의
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
   return (
     <>
       <div className="text-xl-bold text-primary-black-100">후기</div>
@@ -37,12 +53,19 @@ const ActivityReviews: FC<ReviewProps> = ({ averageRating = 0, totalCount = 0, r
         </div>
       </div>
       <div>
-        {reviews.map((review, index) => (
+        {currentReviews.map((review, index) => (
           <div key={review.id}>
             <Review key={review.id} review={review} />
-            {index < reviews.length - 1 && <hr className="my-4 border-t border-primary-black-100 opacity-25" />}
+            {index < currentReviews.length - 1 && <hr className="my-4 border-t border-primary-black-100 opacity-25" />}
           </div>
         ))}
+      </div>
+      <div className="mt-10 md:mt-[90px] xl:mt-[72px]">
+        <Pagination
+          totalPages={Math.ceil(reviews.length / reviewsPerPage)}
+          currentPage={currentPage}
+          onPageChange={handlePageChange}
+        />
       </div>
     </>
   );

--- a/app/(features)/layout.tsx
+++ b/app/(features)/layout.tsx
@@ -1,5 +1,5 @@
-import Footer from "@/components/Footer/Footer";
-import Header from "@/components/Header/Header";
+import Footer from "@footer/Footer";
+import Header from "@header/Header";
 
 export default function FeaturesLayout({
   children,

--- a/app/components/Button/Button.tsx
+++ b/app/components/Button/Button.tsx
@@ -5,6 +5,7 @@ import DefaultButton from "./DefaultButton";
 import FilterButton from "./FilterButton";
 import LoginButton from "./LoginButton";
 import ModalButton from "./ModalButton";
+import PaginationButton from "./PaginationButton";
 import { CancelReservationButton, WriteReviewButton } from "./ReservationButtons";
 import SearchButton from "./SearchButton";
 import SubmitButton from "./SubmitButton";
@@ -17,6 +18,7 @@ const Button = Object.assign(DefaultButton, {
   Search: SearchButton,
   Submit: SubmitButton,
   Modal: ModalButton,
+  Pagination: PaginationButton,
   WriteReview: WriteReviewButton,
   CancelReservation: CancelReservationButton,
 });

--- a/app/components/Button/PaginationButton.tsx
+++ b/app/components/Button/PaginationButton.tsx
@@ -1,0 +1,26 @@
+/*
+    페이지네이션용 버튼: Pagination 컴포넌트용 버튼입니다
+*/
+
+import React from "react";
+import DefaultButton, { DefaultButtonProps } from "./DefaultButton";
+
+interface PaginationButtonProps extends DefaultButtonProps {
+  isActive?: boolean;
+}
+
+const PaginationButton: React.FC<PaginationButtonProps> = ({ isActive = false, children, ...props }) => {
+  const activeClasses = "primary-green-300 text-white";
+  const defaultClasses = "border bg-primary-green-100 border-primary-gray-300";
+
+  return (
+    <DefaultButton
+      className={`flex h-10 w-10 items-center justify-center p-0 ${isActive ? activeClasses : defaultClasses}`}
+      {...props}
+    >
+      {children}
+    </DefaultButton>
+  );
+};
+
+export default PaginationButton;

--- a/app/components/Button/PaginationButton.tsx
+++ b/app/components/Button/PaginationButton.tsx
@@ -15,7 +15,7 @@ const PaginationButton: React.FC<PaginationButtonProps> = ({ isActive = false, c
 
   return (
     <DefaultButton
-      className={`flex h-10 w-10 items-center justify-center p-0 ${isActive ? activeClasses : defaultClasses}`}
+      className={`flex h-10 w-10 items-center justify-center rounded-lg p-0 ${isActive ? activeClasses : defaultClasses}`}
       {...props}
     >
       {children}

--- a/app/components/Pagination/index.tsx
+++ b/app/components/Pagination/index.tsx
@@ -1,0 +1,58 @@
+import Button from "@button/Button";
+import PaginationArrowLeft from "@icon/ic_left.svg";
+import PaginationArrowRight from "@icon/ic_right.svg";
+import Image from "next/image";
+import React from "react";
+
+interface PaginationProps {
+  totalPages: number;
+  currentPage: number;
+  onPageChange: (page: number) => void;
+}
+
+const Pagination: React.FC<PaginationProps> = ({ totalPages, currentPage, onPageChange }) => {
+  // 페이지 변경을 처리하는 함수
+  const handlePageChange = (page: number) => {
+    if (page > 0 && page <= totalPages) {
+      // 페이지가 1 이상이고 총 페이지 수 이내인지 확인
+      onPageChange(page); // 유효한 경우 페이지 변경 함수 호출
+    }
+  };
+
+  return (
+    <div className="flex flex-row items-center justify-center gap-2">
+      <Button.Pagination
+        onClick={() => handlePageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        type={currentPage === 1 ? "disabled" : "white"}
+      >
+        <Image src={PaginationArrowLeft} alt="Previous Page" width={24} height={24} /> {/* 왼쪽 화살표 아이콘 */}
+      </Button.Pagination>
+      {Array.from(
+        { length: totalPages },
+        (
+          _,
+          index, // 총 페이지 수만큼 배열 생성 후 각 페이지 버튼 생성
+        ) => (
+          <Button.Pagination
+            key={index + 1}
+            onClick={() => handlePageChange(index + 1)}
+            isActive={currentPage === index + 1}
+            type={currentPage === index + 1 ? "nomadBlack" : "white"}
+          >
+            {index + 1}
+          </Button.Pagination>
+        ),
+      )}
+      <Button.Pagination
+        onClick={() => handlePageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        type={currentPage === totalPages ? "disabled" : "white"}
+      >
+        <Image src={PaginationArrowRight} alt="Next Page" width={24} height={24} /> {/* 오른쪽 화살표 아이콘 */}
+      </Button.Pagination>
+    </div>
+  );
+};
+
+export default Pagination;


### PR DESCRIPTION
## 🔎 작업 내용
- 체험상세 페이지 후기에 3개씩 review가 보이도록 pagination 적용했습니다.

## 📜 간단한 코드 설명 및 사용설명서
- 세민님이 만드신 Pagination 기반으로 Pagination를 공용 컴포넌트로 개발했습니다.
- Pagination용 공용 버튼 생성했습니다.
- Figma와 차이나는 부분
  -  pagination 버튼이 desktop과 tablet에서 55 * 55, mobile에서 40 * 40 인데, 실제 적용해보니 55*55 너무 크게 느껴져서 40으로 통일했습니다.
  - figma에서는 왼쪽 삼각형 오른쪽 삼각형으로 만들어져 있는데, 세민님께서 처음 만드신 화살표도 좋은 것 같아서 그대로 적용했습니다.
  - 버튼 비활성화 시 `bg-primary-green-100`을 적용해 봤습니다. bg-white보다는 더 나을 것 같아서 해봤는데, 별로면 피드백 해주세요!

## 📷 결과물 (image , gif ..)
### desktop
![image](https://github.com/user-attachments/assets/39269bdf-f2c0-476f-88ba-0f51fb2be402)

### tablet
![image](https://github.com/user-attachments/assets/325645df-c0f7-4b16-b3d6-a1479cff069d)

### mobile
![image](https://github.com/user-attachments/assets/98474cc9-a3f4-4255-a727-76f57df6f3fb)

#추가
![image](https://github.com/user-attachments/assets/5163478e-741a-4281-9707-29e1f2c9ccbc)
border-radius 값이 맞지 않는 것 같아서 rounded에서 rounded-lg로 변경했습니다!

### 👀 공유포인트 및 이슈
- 승인되면, 머지 후 API 작업 시작하려고 합니다.