### PR TITLE
feat: 삭제하기 기능, 체험 생성자에게만 케밥 버튼 보이기 적용

### DIFF
--- a/app/(features)/activity/[activityId]/page.tsx
+++ b/app/(features)/activity/[activityId]/page.tsx
@@ -1,13 +1,12 @@
 /*
   체험 상세 페이지
   Todo: 
-    (1)Dropdown menu- '내가만든 체험인 경우에만 나타나도록 적용
-    (2)내가 만든 체험인 경우 예약카드 보이지 않게하기
-    (3)예약완료시 예약완료 모달창 연결
+    (1)내가 만든 체험인 경우 예약카드 보이지 않게하기
 */
 
-import getActivitiesId from "@api/Activities/getActivitiesId"; // API 함수
+import getActivitiesId from "@api/Activities/getActivitiesId"; // API 함수 (체험 정보)
 import getActivitiesIdRev from "@api/Activities/getActivitiesIdRev"; //API 함수(ReviewData)
+import getUserData from "@api/Users/getUsersMe"; //로그인된 사용자 정보를 가져오는 API 함수
 import ActivityDescription from "../_components/ActivityDescription";
 import ActivityImageGallery from "../_components/ActivityImageGallery";
 import ActivityLocationServer from "../_components/ActivityLocationServer";
@@ -20,6 +19,16 @@ export default async function ActivityPage({ params }: { params: { activityId: s
   const activityId = Number(params.activityId);
   const activity = await getActivitiesId(activityId);
   const images = activity.subImages?.map(image => image.imageUrl) ?? [];
+
+  let user = null;
+
+  try {
+    user = await getUserData(); // 로그인한 사용자의 정보 가져오기
+  } catch (error) {
+    // 로그인하지 않은 경우 또는 사용자 정보를 가져오지 못한 경우, user는 null로 유지됩니다.
+  }
+
+  const isOwner = user && activity.userId === user.id; // 사용자가 만든 체험인지 확인
 
   // 서버에서 fetch로 리뷰 데이터 가져오기
   const initialReviews = await getActivitiesIdRev(activityId);
@@ -36,9 +45,7 @@ export default async function ActivityPage({ params }: { params: { activityId: s
             address={activity.address}
           />
         </div>
-        <div className="flex-none">
-          <DropDownMenu />
-        </div>
+        <div className="flex-none">{isOwner && <DropDownMenu activityId={activityId} />}</div>
       </div>
       <ActivityImageGallery bannerImage={activity.bannerImageUrl} images={images} />
       <div className="flex flex-col gap-6 md:flex-row md:gap-6">

--- a/app/(features)/activity/_components/DropDownMenu.tsx
+++ b/app/(features)/activity/_components/DropDownMenu.tsx
@@ -1,54 +1,123 @@
 /*
   체험 상세 페이지 DropDown 메뉴 + 케밥 버튼
-  Todo: 수정하기, 삭제하기 기능 및 페이지 연결하기
+  Todo: 수정하기 페이지 연결하기
 */
 "use client";
 
-import Dropdown, { DropdownItem, DropdownTrigger } from "@dropdown/DropDown";
+import deleteMyActivitiesId from "@api/MyActivities/deleteMyActivitiesId";
+import Dropdown, { DropdownItem } from "@dropdown/DropDown";
 import KebabBtn from "@icon/ic_meatball.svg";
+import Modal from "@modal/Modal";
+import { useMutation } from "@tanstack/react-query";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { FC, useState } from "react";
 
-const DropDownMenu: FC = () => {
-  const [isOpen, setIsOpen] = useState(false);
+interface DropDownMenuProps {
+  activityId: number; // 액티비티 ID를 프로퍼티로 받습니다.
+}
+
+const DropDownMenu: FC<DropDownMenuProps> = ({ activityId }) => {
+  const router = useRouter();
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      console.log("Deleting activity with ID:", activityId);
+      return deleteMyActivitiesId(activityId);
+    },
+    onSuccess: () => {
+      console.log("Activity deleted successfully.");
+      setModalMessage("삭제가 완료되었습니다.");
+      setIsSuccessModalOpen(true); // 성공 모달 열기
+    },
+    onError: (error: any) => {
+      console.error("Error occurred during deletion:", error);
+
+      let message = "삭제에 실패했습니다.";
+      if (error.response) {
+        const statusCode = error.response.status;
+        console.log(`Error status code: ${statusCode}`);
+
+        switch (statusCode) {
+          case 400:
+            message = "신청 예약이 있는 체험은 삭제할 수 없습니다.";
+            break;
+          case 401:
+            message = "권한이 없습니다.";
+            break;
+          case 403:
+            message = "본인의 체험만 삭제할 수 있습니다.";
+            break;
+          case 404:
+            message = "존재하지 않는 체험입니다.";
+            break;
+          default:
+            message = `서버 오류: ${statusCode}`;
+        }
+      } else if (error.message) {
+        message = error.message;
+      }
+
+      setModalMessage(message);
+      setIsErrorModalOpen(true); // 에러 모달 열기
+    },
+  });
 
   const handleEdit = () => {
     console.log("Edit action triggered");
-    setIsOpen(false);
   };
 
   const handleDelete = () => {
-    console.log("Delete action triggered");
-    setIsOpen(false);
+    console.log("Delete button clicked, opening confirmation modal.");
+    setIsConfirmModalOpen(true);
   };
 
+  const confirmDelete = () => {
+    console.log("Confirm delete clicked.");
+    mutation.mutate();
+    setIsConfirmModalOpen(false);
+  };
+
+  const handleSuccessConfirm = () => {
+    setIsSuccessModalOpen(false);
+    router.push("/");
+  };
+
+  const dropdownItems: DropdownItem[] = [
+    { label: "수정하기", action: handleEdit },
+    { label: "삭제하기", action: handleDelete },
+  ];
+
   return (
-    <div className="relative inline-block text-left">
+    <>
       <Dropdown
-        isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
-        trigger={
-          <DropdownTrigger onClick={() => setIsOpen(!isOpen)}>
-            <Image src={KebabBtn} alt="menu" width={32} height={32} />
-          </DropdownTrigger>
-        }
-      >
-        <div className="absolute right-0 mt-2 w-[140px] origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none md:w-[160px]">
-          <DropdownItem
-            onClick={handleEdit}
-            className="block w-full items-center px-4 py-4 text-sm text-gray-700 hover:bg-gray-100"
-          >
-            수정하기
-          </DropdownItem>
-          <DropdownItem
-            onClick={handleDelete}
-            className="block w-full px-4 py-4 text-sm text-gray-700 hover:bg-gray-100"
-          >
-            삭제하기
-          </DropdownItem>
-        </div>
-      </Dropdown>
-    </div>
+        items={dropdownItems}
+        trigger={<Image src={KebabBtn} alt="menu" width={32} height={32} />}
+        itemClassName="w-[140px] md:w-[160px] h-[58px]"
+      />
+      <Modal.Confirm
+        isOpen={isConfirmModalOpen}
+        onClose={() => setIsConfirmModalOpen(false)}
+        onConfirm={confirmDelete}
+        message="이 체험을 삭제하시겠습니까?"
+      />
+      <Modal.Confirm
+        isOpen={isErrorModalOpen}
+        onClose={() => setIsErrorModalOpen(false)}
+        onConfirm={() => setIsErrorModalOpen(false)}
+        message={modalMessage}
+      />
+      <Modal.Confirm
+        isOpen={isSuccessModalOpen}
+        onClose={handleSuccessConfirm}
+        onConfirm={handleSuccessConfirm}
+        message={modalMessage}
+      />
+    </>
   );
 };
 

--- a/app/api/MyActivities/deleteMyActivitiesId.ts
+++ b/app/api/MyActivities/deleteMyActivitiesId.ts
@@ -1,19 +1,46 @@
+/*
+ * fetchInstance 삭제 이유: Delete하면 Code(204) No Content로 응답이 옵니다.
+ * fetchInstance 안에서는 response가 오면 무조건 JSON parsing하도록 설정되어 있어서
+ * 삭제가 성공했음에도 불구하고, 계속 오류 메시지가 뜹니다.
+ * 그래서 우선 fetchInstance 빼고 삭제가 작동되도록 수정했습니다.
+ */
+
 "use server";
 
-import fetchInstance from "@/utils/fetchInstance";
+import { cookies } from "next/headers";
 
-const deleteMyNotifications = async (activityId: number) => {
+const deleteMyActivitiesId = async (activityId: number) => {
+  const token = cookies().get("accessToken");
+  const headers: HeadersInit = {
+    Accept: "application/json",
+    Authorization: token ? `Bearer ${token.value}` : "",
+  };
+
   try {
-    await fetchInstance(`my-activities/${activityId}`, {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/my-activities/${activityId}`, {
       method: "DELETE",
+      headers: headers,
     });
-  } catch (error) {
-    if (error instanceof Error) {
-      throw new Error(error.message || "Delete notification failed");
-    } else {
-      throw new Error("Delete notification failed");
+
+    if (response.status === 204) {
+      // 204 No Content: 성공적으로 삭제, 응답 본문 없음
+      console.log("Activity successfully deleted, no content to parse.");
+      return;
+    } else if (response.status === 200) {
+      // 200 OK: 성공적으로 삭제, 응답에 데이터 포함
+      const data = await response.json();
+      console.log("Activity successfully deleted:", data);
+      return;
+    } else if (!response.ok) {
+      // 400, 403, 404 등 비정상적인 상태 코드에 대한 처리
+      const errorData = await response.json().catch(() => ({ message: "Unknown error" }));
+      console.error("Deletion failed with status:", response.status);
+      throw new Error(errorData.message || `Failed with status ${response.status}`);
     }
+  } catch (error: any) {
+    console.error("Error during deletion:", error);
+    throw new Error(error.message || "서버 오류로 인해 삭제할 수 없습니다.");
   }
 };
 
-export default deleteMyNotifications;
+export default deleteMyActivitiesId;

--- a/app/components/DropDown/DropDown.tsx
+++ b/app/components/DropDown/DropDown.tsx
@@ -1,94 +1,65 @@
-/*
-  DropDown 메뉴 만들기 위한 공용 컴포넌트
-*/
-"use client";
-
 import { FC, ReactNode, useEffect, useRef, useState } from "react";
 
-// Dropdown 관련 인터페이스
-interface DropdownProps {
-  trigger: ReactNode;
-  isOpen: boolean;
-  onClose: () => void;
-  children: ReactNode;
+export interface DropdownItem {
+  label: string;
+  action: () => void;
 }
 
-// Dropdown 컴포넌트
-const Dropdown: FC<DropdownProps & React.HTMLAttributes<HTMLDivElement>> = ({
-  trigger,
-  isOpen,
-  onClose,
-  children,
-  ...rest
-}) => {
+export interface DropdownProps {
+  items: DropdownItem[];
+  dropdownClassName?: string;
+  itemClassName?: string;
+  trigger: ReactNode;
+}
+
+const Dropdown: FC<DropdownProps> = ({ items, dropdownClassName, itemClassName, trigger }) => {
+  const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
-  const [dropdownWidth, setDropdownWidth] = useState<string | number>("auto");
+
+  const toggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
 
   const handleClickOutside = (event: MouseEvent) => {
     if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-      onClose();
+      setIsOpen(false);
     }
   };
 
-  useEffect(() => {
-    if (isOpen && triggerRef.current) {
-      // 트리거 요소의 너비로 드롭다운 너비를 설정
-      setDropdownWidth(triggerRef.current.offsetWidth);
-    }
-  }, [isOpen]);
+  const handleClickActionBtn = (action: () => void) => {
+    // 공통적인 부분 처리
+    // action 실행
+    action?.();
+  };
 
   useEffect(() => {
-    if (isOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    } else {
-      document.removeEventListener("mousedown", handleClickOutside);
-    }
-
+    document.addEventListener("mousedown", handleClickOutside);
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [isOpen]);
+  }, []);
 
   return (
-    <div className="relative inline-block" ref={triggerRef} {...rest}>
-      <div>{trigger}</div>
+    <div className="relative inline-block" ref={menuRef}>
+      <button onClick={toggleDropdown} className="flex items-center justify-center">
+        {trigger}
+      </button>
       {isOpen && (
-        <div
-          ref={menuRef}
-          className="absolute right-0 z-10 mt-2 rounded bg-white shadow-lg"
-          style={{ width: dropdownWidth }}
-        >
-          {children}
-        </div>
+        <ul className={`absolute right-0 z-10 mt-2 rounded bg-white shadow-lg ${dropdownClassName}`}>
+          {items.map((item, index) => (
+            <li key={index} className={`rounded border border-solid border-primary-gray-300 p-2 ${itemClassName}`}>
+              <button
+                onClick={() => handleClickActionBtn(item.action)}
+                className="md-medium w-full rounded px-4 py-2 text-center text-gray-600 hover:bg-primary-green-100 hover:text-primary-black-100 focus:outline-none md:text-2lg-medium xl:text-2lg-medium"
+              >
+                {item.label}
+              </button>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );
 };
-
-// Dropdown Trigger 컴포넌트
-export const DropdownTrigger: FC<
-  { onClick: () => void; children: ReactNode } & React.HTMLAttributes<HTMLButtonElement>
-> = ({ onClick, children, ...rest }) => (
-  <button onClick={onClick} {...rest}>
-    {children}
-  </button>
-);
-
-// Dropdown Item 컴포넌트
-export const DropdownItem: FC<{ onClick: () => void; children: ReactNode } & React.HTMLAttributes<HTMLDivElement>> = ({
-  onClick,
-  children,
-  className = "",
-  ...rest
-}) => (
-  <div
-    onClick={onClick}
-    className={`md-medium w-full cursor-pointer p-2 text-center text-gray-600 hover:bg-primary-green-100 hover:text-primary-black-100 focus:outline-none md:text-2lg-medium ${className}`}
-    {...rest}
-  >
-    {children}
-  </div>
-);
 
 export default Dropdown;


### PR DESCRIPTION
## 🔎 작업 내용
- 체험 삭제 페이지에 '체험 삭제' 기능을 연결했습니다.
- 로그인한 user와 체험을 만든 user가 같은 경우에만 kebab button이 등장하도록 코드 추가했습니다.

## 📜 간단한 코드 설명 및 사용설명서
- `deleteMyActivitiesId`에서 삭제 요청을 보내고, 삭제 성공하면 No Content가 돌아오는데 현재 fetchInstance에서는 Content가 없음에도 불구하고 JSON으로 파싱하려고 해서, 삭제에 성공했음에도 불구하고 계속 오류메시지가 떴어요. 많은 고민을 하다가, 제가 fetchInstance를 수정하다가 혹시라도 문제가 생길까 하고, 그냥 deleteMyActivitiedId에서 fetchInstance를 빼고 우선 삭제기능을 넣는 방향으로 갔습니다. 이 부분에 대해 어떻게 하면 좋을지 의견,,, 기다리겠습니다! 😣
- 삭제에 성공하면 mainpage로 라우팅 되도록 했습니다!

## 📷 결과물 (image , gif ..)
![image](https://github.com/user-attachments/assets/6aaf73c3-7940-4f3f-879c-4a3604ffa0b4)
![image](https://github.com/user-attachments/assets/261486a8-ada0-4adf-baf3-fba3fcfa84e6)
![image](https://github.com/user-attachments/assets/35300e9f-acef-49a6-9f85-9eae564d8fe5)
![image](https://github.com/user-attachments/assets/28f3c036-21e6-4fb2-a265-f311c590a661)
----
![image](https://github.com/user-attachments/assets/1b133fb8-f748-4345-85f8-39625f52ba7d)
![image](https://github.com/user-attachments/assets/423eb672-e95f-458b-89e7-3c6878c3be3f)


### 👀 공유포인트 및 이슈
- 기존에 올렸던 PR에서 이 전 작업들과 Merge하다가 작업 내용이 많이 날아가고 바뀌어서 새로 작업해서 올렸습니다! (어렵네요 😂)
- 삭제기능 연습하다가 리뷰 많이 달아둔 체험이 날아갔어요...😭😭😭😭😭
- fetchInstance문제.. 