### PR TITLE
refactor: 체험상세페이지

### DIFF
--- a/app/(features)/activity/[activityId]/page.tsx
+++ b/app/(features)/activity/[activityId]/page.tsx
@@ -60,7 +60,7 @@ export default async function ActivityPage({ params }: { params: { activityId: s
         </div>
         {!isOwner && ( // isOwner가 아닌 경우에만 ReservationFloatingBox 렌더링
           <div className="pt-[85px] md:relative md:w-[258px] xl:w-[384px]">
-            <div className="fixed bottom-0 left-0 right-0 z-30 w-full bg-white md:relative md:w-[258px] xl:relative xl:w-[384px]">
+            <div className="fixed bottom-10 left-0 right-0 z-30 w-full bg-white md:relative md:w-[258px] xl:relative xl:w-[384px]">
               <ReservationFloatingBox
                 activityId={activity.id as number}
                 schedules={activity.schedules}

--- a/app/(features)/activity/[activityId]/page.tsx
+++ b/app/(features)/activity/[activityId]/page.tsx
@@ -1,7 +1,5 @@
 /*
   체험 상세 페이지
-  Todo: 
-    (1)내가 만든 체험인 경우 예약카드 보이지 않게하기
 */
 
 import getActivitiesId from "@api/Activities/getActivitiesId"; // API 함수 (체험 정보)
@@ -45,7 +43,11 @@ export default async function ActivityPage({ params }: { params: { activityId: s
             address={activity.address}
           />
         </div>
-        <div className="flex-none">{isOwner && <DropDownMenu activityId={activityId} />}</div>
+        <div className="flex-none">
+          {isOwner && ( // isOwner인 경우에만 DropDownMenu 렌더링
+            <DropDownMenu activityId={activityId} />
+          )}
+        </div>
       </div>
       <ActivityImageGallery bannerImage={activity.bannerImageUrl} images={images} />
       <div className="flex flex-col gap-6 md:flex-row md:gap-6">
@@ -56,15 +58,17 @@ export default async function ActivityPage({ params }: { params: { activityId: s
           <hr className="my-4 border-t border-primary-black-100 opacity-25 md:my-10 md:block" />
           <ActivityReviewClient initialReviews={initialReviews} activityId={activityId} />
         </div>
-        <div className="pt-[85px] md:relative md:w-[258px] xl:w-[384px]">
-          <div className="fixed bottom-0 left-0 right-0 z-30 w-full bg-white md:relative md:w-[258px] xl:relative xl:w-[384px]">
-            <ReservationFloatingBox
-              activityId={activity.id as number}
-              schedules={activity.schedules}
-              price={activity.price}
-            />
+        {!isOwner && ( // isOwner가 아닌 경우에만 ReservationFloatingBox 렌더링
+          <div className="pt-[85px] md:relative md:w-[258px] xl:w-[384px]">
+            <div className="fixed bottom-0 left-0 right-0 z-30 w-full bg-white md:relative md:w-[258px] xl:relative xl:w-[384px]">
+              <ReservationFloatingBox
+                activityId={activity.id as number}
+                schedules={activity.schedules}
+                price={activity.price}
+              />
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/app/(features)/activity/_components/DatePickerStyles.css
+++ b/app/(features)/activity/_components/DatePickerStyles.css
@@ -23,7 +23,7 @@
 /* 오늘(today) 강조 */
 .react-datepicker__day--today {
   font-weight: bold;
-  background-color: #ced8d5;
+  background-color: #ffe4e0;
   border-radius: 8px;
   color: #0b3b2d;
 }
@@ -47,6 +47,7 @@
 
 /* schedule 없는 날 */
 .non-selectable-day {
-  color: gray;
+  color: CBC9CF;
+  text-decoration: line-through;
   pointer-events: none;
 }

--- a/app/(features)/activity/_components/DatePickerStyles.css
+++ b/app/(features)/activity/_components/DatePickerStyles.css
@@ -23,7 +23,7 @@
 /* 오늘(today) 강조 */
 .react-datepicker__day--today {
   font-weight: bold;
-  background-color: #00ac07;
+  background-color: #ced8d5;
   border-radius: 8px;
   color: #0b3b2d;
 }

--- a/app/(features)/activity/_components/DatePickerStyles.css
+++ b/app/(features)/activity/_components/DatePickerStyles.css
@@ -23,7 +23,7 @@
 /* 오늘(today) 강조 */
 .react-datepicker__day--today {
   font-weight: bold;
-  background-color: #ffe4e0;
+  background-color: #00ac07;
   border-radius: 8px;
   color: #0b3b2d;
 }

--- a/app/(features)/activity/_components/DropDownMenu.tsx
+++ b/app/(features)/activity/_components/DropDownMenu.tsx
@@ -26,21 +26,16 @@ const DropDownMenu: FC<DropDownMenuProps> = ({ activityId }) => {
 
   const mutation = useMutation({
     mutationFn: async () => {
-      console.log("Deleting activity with ID:", activityId);
       return deleteMyActivitiesId(activityId);
     },
     onSuccess: () => {
-      console.log("Activity deleted successfully.");
       setModalMessage("삭제가 완료되었습니다.");
       setIsSuccessModalOpen(true); // 성공 모달 열기
     },
     onError: (error: any) => {
-      console.error("Error occurred during deletion:", error);
-
       let message = "삭제에 실패했습니다.";
       if (error.response) {
         const statusCode = error.response.status;
-        console.log(`Error status code: ${statusCode}`);
 
         switch (statusCode) {
           case 400:
@@ -72,12 +67,10 @@ const DropDownMenu: FC<DropDownMenuProps> = ({ activityId }) => {
   };
 
   const handleDelete = () => {
-    console.log("Delete button clicked, opening confirmation modal.");
     setIsConfirmModalOpen(true);
   };
 
   const confirmDelete = () => {
-    console.log("Confirm delete clicked.");
     mutation.mutate();
     setIsConfirmModalOpen(false);
   };

--- a/app/(features)/activity/_components/ReservationFloatingBox.tsx
+++ b/app/(features)/activity/_components/ReservationFloatingBox.tsx
@@ -48,8 +48,22 @@ const ReservationFloatingBox: React.FC<ReservationFloatingBoxProps> = ({ activit
         setConfirmModalOpen(false);
       });
     },
-    onError: (err: Error) => {
-      openConfirmModal(`예약 실패! 😥: ${err.message}`, () => {
+    onError: (err: any) => {
+      let errorMessage = "예약 실패! 😥";
+
+      // 에러 메시지를 err.message에서 가져오기
+      const serverMessage = err.message;
+
+      console.log("Error message:", serverMessage);
+
+      // 500 에러와 관련된 경우 로그인 에러 메시지 처리
+      if (serverMessage.includes("Unauthorized: No refresh token available")) {
+        errorMessage = "로그인 후 예약해주세요. 😊";
+      } else if (serverMessage) {
+        errorMessage = `예약 실패! 😥: ${serverMessage}`;
+      }
+
+      openConfirmModal(errorMessage, () => {
         setConfirmModalOpen(false);
       });
     },

--- a/app/(features)/activity/_components/ReservationFloatingBox.tsx
+++ b/app/(features)/activity/_components/ReservationFloatingBox.tsx
@@ -44,7 +44,7 @@ const ReservationFloatingBox: React.FC<ReservationFloatingBoxProps> = ({ activit
   const reservationMutation = useMutation({
     mutationFn: (newReservation: ReservationRequest) => postActivitiesIdRez(activityId, newReservation),
     onSuccess: () => {
-      openConfirmModal("예약 성공! 😍", () => {
+      openConfirmModal("예약 신청 성공! 😍 예약 확정을 알림을 기다려주세요.", () => {
         setConfirmModalOpen(false);
       });
     },

--- a/app/(features)/activity/_components/ReservationFloatingBox.tsx
+++ b/app/(features)/activity/_components/ReservationFloatingBox.tsx
@@ -4,11 +4,12 @@
 "use client";
 
 import postActivitiesIdRez from "@/api/Activities/postActivitiesIdRez";
+import useWindowSize from "@/hooks/useWindowSize"; // 화면 사이즈 변경시 컴포넌트 내 요소 사이즈 조정 커스텀 훅
 import { ReservationFloatingBoxProps, ReservationRequest } from "@/types/activities.type";
 import Button from "@button/Button";
 import Modal from "@modal/Modal";
 import { useMutation } from "@tanstack/react-query";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import ParticipantCount from "./ParticipantCount";
 import PriceInfo from "./PriceInfo";
 import ScheduleSelector from "./ScheduleSelector";
@@ -19,21 +20,14 @@ const ReservationFloatingBox: React.FC<ReservationFloatingBoxProps> = ({ activit
   const [selectedScheduleId, setSelectedScheduleId] = useState<number | null>(null);
   const selectedSchedule = schedules.find(schedule => schedule.id === selectedScheduleId);
   const [showScheduleSelector, setShowScheduleSelector] = useState<boolean>(false);
-  const [isMobile, setIsMobile] = useState<boolean>(false);
+
+  const windowSize = useWindowSize(); // 커스텀 훅 사용
+  const isMobile = windowSize < 768; // 모바일인지 판단하는 조건
 
   //모달 상태 관리
   const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
   const [confirmModalMessage, setConfirmModalMessage] = useState("");
   const [onConfirmAction, setOnConfirmAction] = useState<() => void>(() => () => {});
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth < 768);
-    };
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
 
   const formatPrice = (amount: number) => {
     return new Intl.NumberFormat("ko-KR").format(amount);

--- a/app/(features)/activity/_components/ReservationFloatingBox.tsx
+++ b/app/(features)/activity/_components/ReservationFloatingBox.tsx
@@ -184,7 +184,7 @@ const ReservationFloatingBox: React.FC<ReservationFloatingBoxProps> = ({ activit
           <div className="hidden md:block xl:block">
             <ParticipantCount count={participantCount} setCount={handleParticipantCountChange} />
           </div>
-          <div className={`pt-4 ${isMobile ? "fixed bottom-4 right-4" : ""}`}>
+          <div className={`pt-4 ${isMobile ? "fixed bottom-14 right-4" : ""}`}>
             <Button.Submit
               onClick={handleReservation}
               className={`h-14 ${isMobile ? "w-[106px]" : "w-auto"}`}

--- a/app/(features)/activity/_components/ReservationFloatingBox.tsx
+++ b/app/(features)/activity/_components/ReservationFloatingBox.tsx
@@ -44,7 +44,7 @@ const ReservationFloatingBox: React.FC<ReservationFloatingBoxProps> = ({ activit
   const reservationMutation = useMutation({
     mutationFn: (newReservation: ReservationRequest) => postActivitiesIdRez(activityId, newReservation),
     onSuccess: () => {
-      openConfirmModal("예약 신청 성공! 😍 예약 확정을 알림을 기다려주세요.", () => {
+      openConfirmModal("예약 신청 성공! 😍 체험 제공자의 예약 확정 알림을 기다려주세요.", () => {
         setConfirmModalOpen(false);
       });
     },

--- a/app/(features)/activity/_components/Review.tsx
+++ b/app/(features)/activity/_components/Review.tsx
@@ -13,8 +13,14 @@ const Review: FC<{ review: ReviewList }> = ({ review }) => {
   return (
     <div className="flex rounded-lg border">
       <div className="mr-4 flex-shrink-0">
-        <div className="h-[45px] w-[45px] overflow-hidden rounded-full">
-          <Image src={profileImageUrl} width={45} height={45} alt={review.user.nickname} className="object-cover" />
+        <div className="relative h-[45px] w-[45px] overflow-hidden rounded-full">
+          <Image
+            src={profileImageUrl}
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            fill
+            alt={review.user.nickname}
+            className="object-cover object-center"
+          />
         </div>
       </div>
       <div className="flex-grow">

--- a/app/(features)/activity/_components/ScheduleSelector.tsx
+++ b/app/(features)/activity/_components/ScheduleSelector.tsx
@@ -79,7 +79,7 @@ const ScheduleSelector: React.FC<ScheduleSelectorProps> = ({ schedules = [], set
         </div>
       </div>
       <div>
-        <h3 className="pb-3 text-xl-bold text-primary-black-100">예약 가능한 시간</h3>
+        <h3 className="pb-3 text-xl-bold text-primary-black-100 md:text-left">예약 가능한 시간</h3>
         <div className="space-x-3 overflow-x-auto whitespace-nowrap text-left">
           {filteredSchedules.length > 0 ? (
             filteredSchedules.map(schedule => (

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["sprint-fe-project.s3.ap-northeast-2.amazonaws.com"],
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## 🔎 작업 내용
- floatingbox:
  - scheduleselector의 datepicker에서 체험 신청 가능한 날짜와 일반 날짜가 육안으로 잘 구별되지 않아 css 코드 수정했습니다.
  - 화면 사이즈 변경에 대해 useWindowSize 훅 적용했습니다.
  - floatingbox가 체험 작성(만든)자가 아닌 경우에만 가능하도록 설정했습니다.
  - 로그인하지 않고 예약 시도할 경우, Unauthorized 메시지가 떠서, 사용자가 '로그인'을 해야하는 상황임을 더 인지할 수 있도록 모달에 뜨는 메시지를 강화했습니다.
  -  floating box의 모바일 위치를 살짝 위로 조정했습니다.
  - 신청을 하더라도, 실질적으로 판매자가 승인을 해야 예약 신청이 되는 것이기 때문에 '예약 완료'라는 메시지가 모호함이 있는 것 같아 전달하는 메시지를 수정했습니다.
- Review: 리뷰 작성자의 프로필 이미지가 잘리는 현상이 있어 Image 컴포넌트를 조정했습니다.
- 이미지 url 관련, domain 삭제하고 remotePatterns만 남겼습니다.

## 📜 간단한 코드 설명 및 사용설명서


## 📷 결과물 (image , gif ..)
- datepicker 수정전:
![image](https://github.com/user-attachments/assets/c5d2233b-e448-4440-9259-bff9cdef9182)
- datepicker 수정후: (지민님 의견 반영)
![image](https://github.com/user-attachments/assets/5315eda5-210b-4669-9d7d-fca95137d8dd)
- 내가 체험 작성자일 때(케밥버튼 있음, 예약박스 없음),
![image](https://github.com/user-attachments/assets/d2b134d3-6b24-491f-a5b8-f208ef24166e)
- 내가 체험 작성자가 아닐 때(케밥버튼 없음, 예약박스 있음),
![image](https://github.com/user-attachments/assets/64e64a2a-afbd-47b1-98e2-1db9de0736e2)
- 예약 완료시 메시지 변경
![image](https://github.com/user-attachments/assets/cb8a4c99-64ee-4aad-a403-23a0188b8f3d)
- 로그인 안하고 예약 신청하는 경우, 로그인 알림 모달 설정
![image](https://github.com/user-attachments/assets/20ebc6f2-6490-437f-80ea-a0db0814b3d9)
- 모바일화면 floatingbox 위치 조정(원래는 바닥에 떠 있었는데, 살짝 위에 떠다니게 만들었어요. 이것도 팀원님들 소중한 피드백 기다립니다!)
![image](https://github.com/user-attachments/assets/ec207a1d-ae06-4d58-8969-424f0b044ddd)
- 문제의 리뷰 프로필 이미지 
![image](https://github.com/user-attachments/assets/990dced8-7a34-4ceb-a4e6-8f495f49c830)
- 코드 변경 후 
![image](https://github.com/user-attachments/assets/e938148c-9d7c-4f98-ac0b-969a3dce5797)

### 👀 공유포인트 및 이슈
- 저의 남은 TODO: 체험 수정페이지 케밥버튼에 연결하기
- 혹시 수정할 거리 생기면 refactoring하기