### PR TITLE
fix: 내 체험관리 중복 호출 문제 해결 & 스타일 조정

### DIFF
--- a/app/(features)/(user)/myactivities/MyActivitiesClient.tsx
+++ b/app/(features)/(user)/myactivities/MyActivitiesClient.tsx
@@ -20,6 +20,7 @@ const MyActivitiesClient: React.FC<MyActivitiesClientProps> = ({ initialData }) 
             reservations={[activity]}
             getImageUrl={(activity: ActivityList) => activity.bannerImageUrl || ""}
             getTitle={(activity: ActivityList) => activity.title}
+            maxTitleLength={18}
             getRating={(activity: ActivityList) => activity.rating}
             getReviewCount={(activity: ActivityList) => activity.reviewCount}
             getPrice={(activity: ActivityList) => activity.price}

--- a/app/(features)/(user)/myactivities/MyActivitiesClient.tsx
+++ b/app/(features)/(user)/myactivities/MyActivitiesClient.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import DropDownMenu from "@/(features)/activity/_components/DropDownMenu";
+import ReservationCard from "@/components/ReservationCard";
+import { ActivitiesData, ActivityList } from "@/types/activities.type";
+
+type MyActivitiesClientProps = {
+  initialData: ActivitiesData;
+};
+
+const MyActivitiesClient: React.FC<MyActivitiesClientProps> = ({ initialData }) => {
+  return (
+    <div className="space-y-2 md:space-y-4 xl:space-y-6">
+      {initialData.activities.length === 0 ? (
+        <div>No activities found.</div>
+      ) : (
+        initialData.activities.map((activity: ActivityList) => (
+          <ReservationCard
+            key={activity.id}
+            reservations={[activity]}
+            getImageUrl={(activity: ActivityList) => activity.bannerImageUrl || ""}
+            getTitle={(activity: ActivityList) => activity.title}
+            getRating={(activity: ActivityList) => activity.rating}
+            getReviewCount={(activity: ActivityList) => activity.reviewCount}
+            getPrice={(activity: ActivityList) => activity.price}
+          >
+            <DropDownMenu activityId={activity.id} />
+          </ReservationCard>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default MyActivitiesClient;

--- a/app/(features)/(user)/myactivities/page.tsx
+++ b/app/(features)/(user)/myactivities/page.tsx
@@ -1,77 +1,28 @@
-"use client";
-
-import DropDownMenu from "@/(features)/activity/_components/DropDownMenu";
-import ReservationCard from "@/components/ReservationCard";
-import { ActivitiesData, ActivityList } from "@/types/activities.type";
 import getMyActivities from "@api/MyActivities/getMyActivities";
 import DefaultButton from "@button/DefaultButton";
 import Link from "next/link";
-import React, { useEffect, useState } from "react";
+import { Suspense } from "react";
+import MyActivitiesClient from "./MyActivitiesClient";
 
-const MyActivities: React.FC = () => {
-  const [activitiesData, setActivitiesData] = useState<ActivitiesData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const fetchActivities = async () => {
-      try {
-        const data = await getMyActivities();
-        setActivitiesData(data);
-      } catch (err) {
-        setError("데이터를 가져오는 데 실패했습니다.");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchActivities();
-  }, []);
-
-  if (loading) {
-    return <div>로딩 중...</div>;
-  }
-
-  if (error) {
-    return <div>{error}</div>;
-  }
-
-  if (!activitiesData || activitiesData.activities.length === 0) {
-    return <div>표시할 데이터가 없습니다.</div>;
-  }
+export default async function MyActivities() {
+  const initialData = await getMyActivities({ size: 20 }); // 서버에서 초기 데이터를 로드
 
   return (
     <div>
-      <div>
-        <div className="mb-4 flex w-full items-center justify-between">
-          <h1 className="font-pretendard text-[32px] font-bold leading-[42px]">내 체험 관리</h1>
-          <Link href="/myactivities/activity-registration">
-            <DefaultButton
-              type="nomadBlack"
-              className="flex h-[48px] w-[120px] items-center justify-center whitespace-nowrap p-[8px] text-sm md:p-[12px] md:text-base lg:p-[16px] lg:text-lg"
-            >
-              체험 등록하기
-            </DefaultButton>
-          </Link>
-        </div>
+      <div className="mb-4 flex w-full items-center justify-between">
+        <h1 className="font-pretendard text-[32px] font-bold leading-[42px]">내 체험 관리</h1>
+        <Link href="/myactivities/activity-registration">
+          <DefaultButton
+            type="nomadBlack"
+            className="flex h-[48px] w-[120px] items-center justify-center whitespace-nowrap p-[8px] text-sm md:p-[12px] md:text-base lg:p-[16px] lg:text-lg"
+          >
+            체험 등록하기
+          </DefaultButton>
+        </Link>
       </div>
-      {activitiesData.activities.map((activity: ActivityList) => (
-        <ReservationCard
-          key={activity.id} // id 사용
-          reservations={activitiesData.activities} // 올바른 타입 전달
-          getImageUrl={(activity: ActivityList) => activity.bannerImageUrl || ""} // 타입 명시 및 null 처리
-          getTitle={(activity: ActivityList) => activity.title} // 타입 명시
-          getRating={(activity: ActivityList) => activity.rating} // 타입 명시
-          getReviewCount={(activity: ActivityList) => activity.reviewCount} // 타입 명시
-          getPrice={(activity: ActivityList) => activity.price} // 타입 명시
-        >
-          {(reservation: ActivityList) => (
-            <DropDownMenu activityId={reservation.id} /> // id 사용
-          )}
-        </ReservationCard>
-      ))}
+      <Suspense fallback={<div>Loading...</div>}>
+        <MyActivitiesClient initialData={initialData} />
+      </Suspense>
     </div>
   );
-};
-
-export default MyActivities;
+}

--- a/app/components/ReservationCard/PriceComponent.tsx
+++ b/app/components/ReservationCard/PriceComponent.tsx
@@ -1,0 +1,24 @@
+/*
+ * 가격 컴포넌트
+ */
+
+import React from "react";
+
+interface PriceComponentProps<T> {
+  getPrice?: (item: T) => number;
+  item: T;
+  render?: (formattedPrice: string) => React.ReactNode;
+}
+
+const PriceComponent = <T,>({ getPrice, item, render }: PriceComponentProps<T>) => {
+  const formattedPrice = getPrice
+    ? new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "KRW",
+      }).format(getPrice(item))
+    : "";
+
+  return <>{render ? render(formattedPrice) : <span>{formattedPrice}</span>}</>;
+};
+
+export default PriceComponent;

--- a/app/components/ReservationCard/index.tsx
+++ b/app/components/ReservationCard/index.tsx
@@ -62,7 +62,7 @@ const PriceAndChildrenComponent = <T,>({
   item,
 }: {
   getPrice?: (item: T) => number;
-  children?: React.ReactNode;
+  children?: React.ReactNode | ((reservation: T) => React.ReactNode);
   item: T;
 }) => {
   return (
@@ -77,7 +77,7 @@ const PriceAndChildrenComponent = <T,>({
           </div>
         )}
       />
-      {children}
+      {typeof children === "function" ? children(item) : children}
     </div>
   );
 };
@@ -91,7 +91,7 @@ interface ReservationCardProps<T> {
   getReviewCount?: (item: T) => number;
   getCategory?: (item: T) => string;
   getPrice?: (item: T) => number;
-  children?: (reservation: T) => React.ReactNode;
+  children?: React.ReactNode;
 }
 
 const ReservationCard = <T,>({
@@ -129,7 +129,7 @@ const ReservationCard = <T,>({
               <SubtitleComponent getSubtitle={getSubtitle} item={reservation} />
               {/* <5> 가격 및 자식 컴포넌트 */}
               <PriceAndChildrenComponent getPrice={getPrice} item={reservation}>
-                {children && children(reservation)}
+                {children}
               </PriceAndChildrenComponent>
             </div>
           </div>

--- a/app/components/ReservationCard/index.tsx
+++ b/app/components/ReservationCard/index.tsx
@@ -129,7 +129,7 @@ const ReservationCard = <T,>({
   children,
 }: ReservationCardProps<T>) => {
   return (
-    <div className="mx-auto flex min-w-[340px] flex-col gap-2 md:min-w-[440px] md:gap-4 xl:w-[800px] xl:gap-6">
+    <div className="mx-auto flex min-w-[340px] flex-col gap-2 md:min-w-[440px] md:max-w-[800px] md:gap-4 xl:gap-6">
       {reservations.map((reservation, index) => (
         <div
           key={index}

--- a/app/components/ReservationCard/index.tsx
+++ b/app/components/ReservationCard/index.tsx
@@ -1,11 +1,11 @@
-import star from "@icon/ic_star_on.svg";
+import miniStar from "@icon/mini_star.svg";
 import Image from "next/image";
 import React from "react";
 
 // <1> 이미지 컴포넌트
 const ImageComponent = <T,>({ getImageUrl, item }: { getImageUrl: (item: T) => string; item: T }) => (
   <div className="relative h-[128px] w-[128px] flex-shrink-0 overflow-hidden rounded-l-3xl md:h-[156px] md:w-[156px] xl:h-[204px] xl:w-[204px]">
-    <Image src={getImageUrl(item)} priority layout="fill" objectFit="cover" alt="" />
+    <Image src={getImageUrl(item)} priority layout="fill" objectFit="cover" alt="체험 배너 사진" />
   </div>
 );
 
@@ -21,14 +21,14 @@ const RatingComponent = <T,>({
   getCategory?: (item: T) => string;
   item: T;
 }) => (
-  <div className="text-sm font-bold md:text-lg">
+  <div className="text-sm-semibold text-primary-black-200 md:text-md-semibold xl:text-lg-semibold">
     {getCategory ? (
       <span>{getCategory(item)}</span>
     ) : getRating && getReviewCount ? (
       <span className="flex items-center space-x-[4px] md:space-x-[6px]">
-        <Image src={star} alt="rating" width={16} height={16} />
-        <span>{getRating(item)}</span>
-        <span>({getReviewCount(item)})</span>
+        <Image src={miniStar} alt="rating" width={19} height={19} />
+        <span className="font-bold">{getRating(item)}</span>
+        <span className="text-primary-gray-800">({getReviewCount(item)})</span>
       </span>
     ) : null}
   </div>
@@ -46,6 +46,8 @@ const SubtitleComponent = <T,>({ getSubtitle, item }: { getSubtitle?: (item: T) 
   </div>
 );
 
+import PriceComponent from "./PriceComponent";
+
 // <5> 가격 및 자식 컴포넌트
 const PriceAndChildrenComponent = <T,>({
   getPrice,
@@ -56,16 +58,18 @@ const PriceAndChildrenComponent = <T,>({
   children?: React.ReactNode;
   item: T;
 }) => {
-  const formattedPrice = getPrice
-    ? new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "KRW",
-      }).format(getPrice(item)) + "/인"
-    : "";
-
   return (
     <div className="flex w-full items-center justify-between">
-      <div className="md:text-sm-regular text-xs-regular xl:text-[18px]">{formattedPrice}</div>
+      <PriceComponent
+        getPrice={getPrice}
+        item={item}
+        render={formattedPrice => (
+          <div className="flex items-center text-lg-semibold text-primary-gray-800 md:text-xl-semibold xl:text-2xl-semibold">
+            <span>{formattedPrice}</span>
+            <span className="md:text-lg-16px-medium ml-1 text-md-regular text-gray-500 xl:text-lg-medium">/인</span>
+          </div>
+        )}
+      />
       {children}
     </div>
   );
@@ -95,11 +99,11 @@ const ReservationCard = <T,>({
   children,
 }: ReservationCardProps<T>) => {
   return (
-    <div className="mx-auto flex flex-col gap-2 md:gap-4 xl:gap-6">
+    <div className="mx-auto flex flex-col gap-2 md:w-[429px] md:gap-4 xl:w-[792px] xl:gap-6">
       {reservations.map((reservation, index) => (
         <div
           key={index}
-          className="flex h-[128px] rounded-3xl border border-solid border-gray-300 bg-white md:h-[156px] md:w-[429px] xl:h-[204px] xl:w-[792px]"
+          className="flex h-[128px] rounded-3xl border border-solid border-gray-300 bg-white md:h-[156px] xl:h-[204px]"
         >
           {/* <1> 이미지 컴포넌트 */}
           <ImageComponent getImageUrl={getImageUrl} item={reservation} />

--- a/app/components/ReservationCard/index.tsx
+++ b/app/components/ReservationCard/index.tsx
@@ -42,9 +42,30 @@ const RatingComponent = <T,>({
 );
 
 // <3> 제목 컴포넌트
-const TitleComponent = <T,>({ getTitle, item }: { getTitle: (item: T) => string; item: T }) => (
-  <div className="text-md-bold md:text-lg-bold xl:text-xl-bold">{getTitle(item)}</div>
-);
+const truncateTitle = (title: string, maxLength: number) => {
+  return title.length > maxLength ? `${title.slice(0, maxLength)}...` : title;
+};
+
+const TitleComponent = <T,>({
+  getTitle,
+  item,
+  maxTitleLength,
+}: {
+  getTitle: (item: T) => string;
+  item: T;
+  maxTitleLength?: number;
+}) => {
+  const title = getTitle(item);
+  const truncatedTitle = maxTitleLength ? truncateTitle(title, maxTitleLength) : title;
+  return (
+    <div className="text-md-bold md:text-lg-bold xl:text-xl-bold">
+      {/* 모바일에서는 제목을 잘라서 표시 */}
+      <span className="block md:hidden">{truncatedTitle}</span>
+      {/* 태블릿과 PC에서는 원래 제목 표시 */}
+      <span className="hidden md:block">{title}</span>
+    </div>
+  );
+};
 
 // <4> 서브타이틀 컴포넌트
 const SubtitleComponent = <T,>({ getSubtitle, item }: { getSubtitle?: (item: T) => string; item: T }) => (
@@ -86,6 +107,7 @@ interface ReservationCardProps<T> {
   reservations: T[];
   getImageUrl: (item: T) => string;
   getTitle: (item: T) => string;
+  maxTitleLength?: number;
   getSubtitle?: (item: T) => string;
   getRating?: (item: T) => number;
   getReviewCount?: (item: T) => number;
@@ -98,6 +120,7 @@ const ReservationCard = <T,>({
   reservations,
   getImageUrl,
   getTitle,
+  maxTitleLength,
   getSubtitle,
   getRating,
   getReviewCount,
@@ -106,7 +129,7 @@ const ReservationCard = <T,>({
   children,
 }: ReservationCardProps<T>) => {
   return (
-    <div className="mx-auto flex flex-col gap-2 md:w-[429px] md:gap-4 xl:w-[792px] xl:gap-6">
+    <div className="mx-auto flex min-w-[340px] flex-col gap-2 md:min-w-[440px] md:gap-4 xl:w-[800px] xl:gap-6">
       {reservations.map((reservation, index) => (
         <div
           key={index}
@@ -124,7 +147,7 @@ const ReservationCard = <T,>({
                 item={reservation}
               />
               {/* <3> 제목 컴포넌트 */}
-              <TitleComponent getTitle={getTitle} item={reservation} />
+              <TitleComponent getTitle={getTitle} item={reservation} maxTitleLength={maxTitleLength} />
               {/* <4> 서브타이틀 컴포넌트 */}
               <SubtitleComponent getSubtitle={getSubtitle} item={reservation} />
               {/* <5> 가격 및 자식 컴포넌트 */}

--- a/app/components/ReservationCard/index.tsx
+++ b/app/components/ReservationCard/index.tsx
@@ -5,7 +5,14 @@ import React from "react";
 // <1> 이미지 컴포넌트
 const ImageComponent = <T,>({ getImageUrl, item }: { getImageUrl: (item: T) => string; item: T }) => (
   <div className="relative h-[128px] w-[128px] flex-shrink-0 overflow-hidden rounded-l-3xl md:h-[156px] md:w-[156px] xl:h-[204px] xl:w-[204px]">
-    <Image src={getImageUrl(item)} priority layout="fill" objectFit="cover" alt="체험 배너 사진" />
+    <Image
+      src={getImageUrl(item)}
+      priority
+      fill
+      alt="체험 배너 사진"
+      sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+      style={{ objectFit: "cover" }}
+    />
   </div>
 );
 


### PR DESCRIPTION
## 🔎 작업 내용
- 체험 관리에서 data fetch가 중복으로 이루어지고 있어서 수정함
- 내 체험관리 페이지 불러오는 속도가 너무 느려서 server component/ client component 분리함
- 스타일 조정함(모바일에서 제목의 길이가 길어지면서 스타일이 깨지는 문제 => mobile에서 title 최대 길이 지정함

## 📷 결과물 (image , gif ..)
PC
![image](https://github.com/user-attachments/assets/26ee2325-ece3-46e2-ac29-11c97c34f17e)
Tablet
![image](https://github.com/user-attachments/assets/f6c212f6-7371-47a0-b389-6b9d5e336c54)
Mobile
![image](https://github.com/user-attachments/assets/7c8e7e7c-bbbc-4463-800d-d4a9526ba22e)


### 👀 공유포인트 및 이슈
- 무한 스크롤 어렵네요... 이어서 작업해보겠습니다... ㅠ.ㅡ